### PR TITLE
Add left margin to .player-title on desktop

### DIFF
--- a/assets/templates/_style.gohtml
+++ b/assets/templates/_style.gohtml
@@ -177,5 +177,9 @@
 		.mobile-double {
 			font-size: 100%;
 		}
+
+		.player-title {
+			margin-left: 125px;
+		}
 	}
 </style>


### PR DESCRIPTION
Close #2 

I added a bit of margin to the left of the track title in the player. This removes the overlap with the cover art for **very, very** long titles. 
I applied this only in the desktop media query because the mobile interface doesn't have the cover art. :)

I had some problems running the app so far, so I didn't test it locally yet. 

