### PR TITLE
Bug fix: "The `trial_end` date has to be at least 2 days in the future"

### DIFF
--- a/web/stripe.go
+++ b/web/stripe.go
@@ -26,11 +26,6 @@ import (
 	"github.com/guregu/intertube/tube"
 )
 
-const (
-	stripePlanIDLittle = "prod_IcUzPWt5iyHHUg"
-	stripePriceLittle  = "price_1I1FzcKpetgr0YLEljmXzSVH"
-)
-
 var (
 	stripePublicKey string
 	stripeSigSecret string // for webhook
@@ -98,7 +93,7 @@ func stripeCheckout(ctx context.Context, w http.ResponseWriter, r *http.Request)
 		email = stripe.String(u.Email)
 	}
 	var subparam *stripe.CheckoutSessionSubscriptionDataParams
-	if !u.TrialOver && u.TimeRemaining() > time.Hour*24*2 {
+	if !u.TrialOver && u.TimeRemaining() > (2*time.Hour*24)+(10*time.Minute) {
 		subparam = &stripe.CheckoutSessionSubscriptionDataParams{
 			TrialEnd: stripe.Int64(u.PlanExpire.UTC().Unix()),
 		}
@@ -114,7 +109,7 @@ func stripeCheckout(ctx context.Context, w http.ResponseWriter, r *http.Request)
 		Customer:          customerID,
 
 		LineItems: []*stripe.CheckoutSessionLineItemParams{
-			&stripe.CheckoutSessionLineItemParams{
+			{
 				Price:    stripe.String(price),
 				Quantity: stripe.Int64(1),
 			},

--- a/web/stripe.go
+++ b/web/stripe.go
@@ -98,7 +98,7 @@ func stripeCheckout(ctx context.Context, w http.ResponseWriter, r *http.Request)
 		email = stripe.String(u.Email)
 	}
 	var subparam *stripe.CheckoutSessionSubscriptionDataParams
-	if !u.TrialOver && u.TimeRemaining() > time.Hour*24 {
+	if !u.TrialOver && u.TimeRemaining() > time.Hour*24*2 {
 		subparam = &stripe.CheckoutSessionSubscriptionDataParams{
 			TrialEnd: stripe.Int64(u.PlanExpire.UTC().Unix()),
 		}


### PR DESCRIPTION
The intention here is to let people roll over their trial time when subscribing, but it seems there's a weird limit of >2 days.

```
Panic! {"status":400,"message":"The `trial_end` date has to be at least 2 days in the future.","param":"subscription_data[trial_end]","request_id":"xxxx","type":"invalid_request_error"}
```